### PR TITLE
Update to rustc 1.97.0-nightly

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,4 @@ target = "m68k-bare-metal.json"
 
 [unstable]
 build-std = ["core"]
+json-target-spec = true

--- a/m68k-bare-metal.json
+++ b/m68k-bare-metal.json
@@ -33,7 +33,7 @@
   "target-endian": "big",
   "target-family": ["unix"],
   "target-mcount": "_mcount",
-  "target-pointer-width": "32",
+  "target-pointer-width": 32,
   "pre-link-args": {
     "gcc": [
       "-g",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 #![allow(static_mut_refs, dead_code)]
-#![feature(asm_experimental_arch, naked_functions)]
+#![feature(asm_experimental_arch)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
After these changes, the build works, produces the `out/a.exe` HUNK.

The executable however hangs on my fs-uae A500, no idea why yet.